### PR TITLE
Update path based on type loaded

### DIFF
--- a/src/getComponents.js
+++ b/src/getComponents.js
@@ -4,6 +4,7 @@ import getLoader from 'prismjs/dependencies.js';
 const getPath = type => name =>
     `prismjs/${config[type].meta.path.replace(/\{id\}/g, name)}`;
 
+const isPlugin = dep => config.plugins[dep] != null;
 const getNoCSS = (type, name) => config[type][name].noCSS;
 
 const getThemePath = theme => {
@@ -17,13 +18,14 @@ const getThemePath = theme => {
 };
 
 const getPluginPath = getPath('plugins');
+const getLanguagePath = getPath('languages');
 
 export default ({ languages = [], plugins = [], theme, css = false } = {}) => [
-    ...getLoader(config, languages).getIds().map(getPath('languages')),
-    ...getLoader(config, plugins).getIds().reduce((deps, dep) => {
-        const add = [getPluginPath(dep)];
+    ...getLoader(config, [...languages, ...plugins]).getIds().reduce((deps, dep) => {
+        // Plugins can have language dependencies.
+        const add = [isPlugin(dep) ? getPluginPath(dep) : getLanguagePath(dep)];
 
-        if (css && !getNoCSS('plugins', dep)) {
+        if (css && isPlugin(dep) && !getNoCSS('plugins', dep)) {
             add.unshift(getPluginPath(dep) + '.css');
         }
 

--- a/test/fixtures/issue-39/expected.js
+++ b/test/fixtures/issue-39/expected.js
@@ -1,0 +1,10 @@
+import Prism from "prismjs/components/prism-core";
+import "prismjs/components/prism-clike";
+import "prismjs/components/prism-javascript";
+import "prismjs/plugins/line-numbers/prism-line-numbers.css";
+import "prismjs/plugins/line-numbers/prism-line-numbers";
+import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
+import "prismjs/components/prism-diff";
+import "prismjs/plugins/diff-highlight/prism-diff-highlight.css";
+import "prismjs/plugins/diff-highlight/prism-diff-highlight";
+import "prismjs/themes/prism.css";

--- a/test/fixtures/issue-39/options.json
+++ b/test/fixtures/issue-39/options.json
@@ -1,0 +1,6 @@
+{
+  "languages": ["javascript"],
+  "plugins": ["line-numbers", "normalize-whitespace", "diff-highlight"],
+  "theme": "default",
+  "css": true
+}


### PR DESCRIPTION
Use the loader for one single load, rather than two separate
loads.

Fixes #39.