### PR TITLE
Added support for loading all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In your .babelrc, register the plugin and configure its dependencies:
 
 Each key are used as follows:
 
-* `languages`: Array of languages to include in the bundle. Those languages can be found [here](http://prismjs.com/#languages-list).
+* `languages`: Array of languages to include in the bundle or `"all"` to include all languages. Those languages can be found [here](http://prismjs.com/#languages-list).
 * `plugins`: Array of plugins to include in the bundle. Those plugins can be found [here](http://prismjs.com/#plugins).
 * `theme`: Name of theme to include in the bundle. Themes can be found [here](http://prismjs.com/). Use `lower-kebab-case` for the theme name, e.g. `solarized-light`.
 * `css`: Boolean indicating whether to include `.css` files in the result. Defaults to `false`. If `true`, `import`s will be added for `.css` files. Must be `true` in order for `theme` to work.

--- a/src/getComponents.js
+++ b/src/getComponents.js
@@ -49,9 +49,7 @@ const getLanguagePath = getPath('languages');
  * @property {string} [theme]
  * @property {boolean} [css]
  */
-export default (options = {}) => {
-    let { languages = [], plugins = [], theme, css = false } = options;
-
+export default ({ languages = [], plugins = [], theme, css = false } = {}) => {
     if (languages === 'all') {
         languages = Object.keys(config.languages).filter(l => l !== 'meta');
     }

--- a/src/getComponents.js
+++ b/src/getComponents.js
@@ -1,12 +1,31 @@
+/* eslint-disable valid-jsdoc */
 import config from 'prismjs/components.js';
 import getLoader from 'prismjs/dependencies.js';
 
+/**
+ * @param {string} type
+ * @returns {(name: string) => string}
+ */
 const getPath = type => name =>
     `prismjs/${config[type].meta.path.replace(/\{id\}/g, name)}`;
 
+/**
+ * @param {string} dep
+ * @returns {boolean}
+ */
 const isPlugin = dep => config.plugins[dep] != null;
-const getNoCSS = (type, name) => config[type][name].noCSS;
 
+/**
+ * @param {string} type
+ * @param {string} name
+ * @returns {boolean}
+ */
+const getNoCSS = (type, name) => !!config[type][name].noCSS;
+
+/**
+ * @param {string} theme
+ * @returns {string}
+ */
 const getThemePath = theme => {
     if (theme === 'default') {
         theme = 'prism';
@@ -20,16 +39,34 @@ const getThemePath = theme => {
 const getPluginPath = getPath('plugins');
 const getLanguagePath = getPath('languages');
 
-export default ({ languages = [], plugins = [], theme, css = false } = {}) => [
-    ...getLoader(config, [...languages, ...plugins]).getIds().reduce((deps, dep) => {
-        // Plugins can have language dependencies.
-        const add = [isPlugin(dep) ? getPluginPath(dep) : getLanguagePath(dep)];
+/**
+ * @param {Options} [options]
+ * @returns {string[]}
+ *
+ * @typedef Options
+ * @property {string[] | 'all'} [languages]
+ * @property {string[]} [plugins]
+ * @property {string} [theme]
+ * @property {boolean} [css]
+ */
+export default (options = {}) => {
+    let { languages = [], plugins = [], theme, css = false } = options;
 
-        if (css && isPlugin(dep) && !getNoCSS('plugins', dep)) {
-            add.unshift(getPluginPath(dep) + '.css');
-        }
+    if (languages === 'all') {
+        languages = Object.keys(config.languages).filter(l => l !== 'meta');
+    }
 
-        return [...deps, ...add];
-    }, []),
-    ...(css && theme ? [getThemePath(theme)] : [])
-];
+    return [
+        ...getLoader(config, [...languages, ...plugins]).getIds().reduce((deps, dep) => {
+            // Plugins can have language dependencies.
+            const add = [isPlugin(dep) ? getPluginPath(dep) : getLanguagePath(dep)];
+
+            if (css && isPlugin(dep) && !getNoCSS('plugins', dep)) {
+                add.unshift(getPluginPath(dep) + '.css');
+            }
+
+            return [...deps, ...add];
+        }, /** @type {string[]} */([])),
+        ...(css && theme ? [getThemePath(theme)] : [])
+    ];
+};

--- a/test/index.js
+++ b/test/index.js
@@ -24,4 +24,18 @@ describe('PrismJS Configuration', () => {
             assert.equal(actual.trim(), expected.trim());
         });
     });
+
+    it(`should work with all languages`, () => {
+        const actual = transformSync('import Prism from "prismjs";', {
+            plugins: [
+                [plugin, { languages: 'all' }]
+            ],
+            babelrc: false
+        }).code;
+
+        // We expect an import for Prism core followed by 200-300 languages
+        assert.match(actual,
+            /^.+\n(?:\s*import "prismjs\/components\/prism-[\w-]+";){100,}\s*$/
+        );
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -34,8 +34,9 @@ describe('PrismJS Configuration', () => {
         }).code;
 
         // We expect an import for Prism core followed by 200-300 languages
-        assert.match(actual,
-            /^.+\n(?:\s*import "prismjs\/components\/prism-[\w-]+";){100,}\s*$/
-        );
+        if (!/^.+\n(?:\s*import "prismjs\/components\/prism-[\w-]+";){100,}\s*$/
+            .test(actual)) {
+            assert.fail();
+        }
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -34,9 +34,7 @@ describe('PrismJS Configuration', () => {
         }).code;
 
         // We expect an import for Prism core followed by 200-300 languages
-        if (!/^.+\n(?:\s*import "prismjs\/components\/prism-[\w-]+";){100,}\s*$/
-            .test(actual)) {
-            assert.fail();
-        }
+        assert.ok(/^.+\n(?:\s*import "prismjs\/components\/prism-[\w-]+";){100,}\s*$/
+            .test(actual));
     });
 });


### PR DESCRIPTION
This resolves #7.

You can now load all languages with the config:

```js
{
    "languages": "all",
    ...
}
```

---

I also added a bunch of type annotations. Hope that's ok. If you don't want them, I'll remove them.