### PR TITLE
fix: update theme name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Each key are used as follows:
 
 * `languages`: Array of languages to include in the bundle. Those languages can be found [here](http://prismjs.com/#languages-list).
 * `plugins`: Array of plugins to include in the bundle. Those plugins can be found [here](http://prismjs.com/#plugins).
-* `theme`: Name of theme to include in the bundle. Themes can be found [here](http://prismjs.com/). Use `lower-kebab-case` for the theme name, e.g. `solarized-light`.
+* `theme`: Name of theme to include in the bundle. Themes can be found [here](http://prismjs.com/). Use `lower-kebab-case` for the theme name, e.g. `solarizedlight`.
 * `css`: Boolean indicating whether to include `.css` files in the result. Defaults to `false`. If `true`, `import`s will be added for `.css` files. Must be `true` in order for `theme` to work.


### PR DESCRIPTION
Update doc for resolving issue [#108](https://github.com/mAAdhaTTah/babel-plugin-prismjs/issues/101), as the `solarized light` theme's filename changed.